### PR TITLE
.gitignore updated, wrong filename in README fixed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 *.o
-LaserTank
+*~
+.DS_Store
+build/*

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ make -j8
 
 Copy resources near executable (or make links):
 ```
-cp ../data.lvl ../data01.pak ../data01.pak ../DejaVuSans.ttf .
+cp ../data.lvl ../data01.pak ../data02.pak ../DejaVuSans.ttf .
 ```
 
 Run game:


### PR DESCRIPTION
Small fixes.
1) Wrong filename in README. 
2) .gitignore: support for possible mac os port, build directory should be ignored
